### PR TITLE
HAT-P-65_a899e

### DIFF
--- a/systems/HAT-P-65.xml
+++ b/systems/HAT-P-65.xml
@@ -1,0 +1,28 @@
+<star>
+  <name>HAT-P-65</name>
+  <mass errorplus="0.05" errorminus="0.05">1.212</mass>
+  <radius errorplus="0.01" errorminus="0.01">1.86</radius>
+  <magV>13.15</magV>
+  <magH></magH>
+  <magJ></magJ>
+  <temperature errorplus="51.0" errorminus="51.0">5835.0</temperature>
+  <metallicity errorplus="0.08" errorminus="0.08">0.1</metallicity>
+  <spectraltype></spectraltype>
+  <age errorplus="0.6" errorminus="0.6">5.46</age>
+  <planet>
+    <name>HAT-P-65 b</name>
+    <mass>0.52700</mass>
+    <period>2.60545520</period>
+    <semimajoraxis>0.039510</semimajoraxis>
+    <eccentricity errorplus="0.0" errorminus="0.3">0.3</eccentricity>
+    <periastron errorplus="" errorminus=""></periastron>
+    <periastrontime errorplus="" errorminus=""></periastrontime>
+    <detectionMethod>IDK</detectionMethod>
+    <lastUpdate>16/09/12</lastUpdate>
+    <discovery>2016</discovery>
+    <eccentricity errorplus="" errorminus="">0.304000</eccentricity>
+    <discoverymethod>Transit</discoverymethod>
+    <lastupdate>2016-09-15</lastupdate>
+    <discoveryyear>2016</discoveryyear>
+  </planet>
+</star>


### PR DESCRIPTION
Updated HAT-P-65. Time Stamp: 19/11/2016 6:01:10 PM
Sources:
[HAT-P-65 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=HAT-P-65+b)
