### PR TITLE
HAT-P-66_2qmkh

### DIFF
--- a/systems/HAT-P-66.xml
+++ b/systems/HAT-P-66.xml
@@ -1,0 +1,27 @@
+<star>
+  <name>HAT-P-66</name>
+  <mass errorplus="0.107" errorminus="0.0054">1.255</mass>
+  <radius errorplus="0.151" errorminus="0.095">1.881</radius>
+  <magV>13.0</magV>
+  <magH></magH>
+  <magJ></magJ>
+  <temperature errorplus="50.0" errorminus="50.0">6002.0</temperature>
+  <metallicity errorplus="0.08" errorminus="0.08">0.035</metallicity>
+  <spectraltype></spectraltype>
+  <age errorplus="0.52" errorminus="0.12">4.66</age>
+  <planet>
+    <name>HAT-P-66 b</name>
+    <mass>0.78300</mass>
+    <period>2.97208600</period>
+    <semimajoraxis>0.043630</semimajoraxis>
+    <eccentricity errorplus="" errorminus="">0.090000</eccentricity>
+    <periastron errorplus="" errorminus=""></periastron>
+    <periastrontime errorplus="" errorminus=""></periastrontime>
+    <detectionMethod>IDK</detectionMethod>
+    <lastUpdate>16/09/12</lastUpdate>
+    <discovery>2016</discovery>
+    <discoverymethod>Transit</discoverymethod>
+    <lastupdate>2016-09-15</lastupdate>
+    <discoveryyear>2016</discoveryyear>
+  </planet>
+</star>


### PR DESCRIPTION
Updated HAT-P-66. Time Stamp: 19/11/2016 6:01:11 PM
Sources:
[HAT-P-66 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=HAT-P-66+b)
