### PR TITLE
WASP-17_de7ra

### DIFF
--- a/systems/WASP-17.xml
+++ b/systems/WASP-17.xml
@@ -1,38 +1,54 @@
 <system>
-	<name>WASP-17</name>
-	<rightascension>15 59 51</rightascension>
-	<declination>-28 03 42</declination>
-	<distance errorminus="60" errorplus="60">400</distance>
-	<star>
-		<mass>1.306</mass>
-		<radius>1.572</radius>
-		<magV>11.6</magV>
-		<magR>11.31</magR>
-		<magB errorminus="0.08" errorplus="0.08">11.83</magB>
-		<magI errorminus="0.02" errorplus="0.02">10.92</magI>
-		<magJ errorminus="0.027" errorplus="0.027">10.509</magJ>
-		<magH errorminus="0.024" errorplus="0.024">10.319</magH>
-		<magK errorminus="0.027" errorplus="0.027">10.224</magK>
-		<metallicity errorminus="0.09" errorplus="0.09">-0.19</metallicity>
-		<spectraltype>F4</spectraltype>
-		<planet>
-			<name>WASP-17 b</name>
-			<name>2MASS J15595095-2803422 b</name>
-			<list>Confirmed planets</list>
-			<mass>0.486</mass>
-			<radius>1.991</radius>
-			<period>3.735438</period>
-			<semimajoraxis>0.0515</semimajoraxis>
-			<eccentricity>0.028</eccentricity>
-			<inclination>86.83</inclination>
-			<transittime errorminus="0.00027" errorplus="0.00027" unit="BJD">2454577.85879</transittime>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>12/04/08</lastupdate>
-			<discoveryyear>2009</discoveryyear>
-			<temperature>1517.8</temperature>
-			<istransiting>1</istransiting>
-		</planet>
-		<name>WASP-17</name>
-		<temperature>6650.0</temperature>
-	</star>
+  <name>WASP-17</name>
+  <rightascension>15 59 51</rightascension>
+  <declination>-28 03 42</declination>
+  <distance errorminus="60" errorplus="60">400</distance>
+  <mass errorplus="-0.13" errorminus="-0.13">1.2</mass>
+  <radius errorplus="-0.18" errorminus="-0.18">1.38</radius>
+  <magV>11.6</magV>
+  <magH></magH>
+  <magJ></magJ>
+  <temperature errorplus="80.0" errorminus="80.0">6650.0</temperature>
+  <metallicity errorplus="0.09" errorminus="0.09">-0.19</metallicity>
+  <spectraltype>F4</spectraltype>
+  <age errorplus="-2.6" errorminus="-2.6">3.0</age>
+  <star>
+    <name>WASP-17</name>
+    <mass>1.306</mass>
+    <radius>1.572</radius>
+    <magV>11.6</magV>
+    <magR>11.31</magR>
+    <magB errorminus="0.08" errorplus="0.08">11.83</magB>
+    <magI errorminus="0.02" errorplus="0.02">10.92</magI>
+    <magJ errorminus="0.027" errorplus="0.027">10.509</magJ>
+    <magH errorminus="0.024" errorplus="0.024">10.319</magH>
+    <magK errorminus="0.027" errorplus="0.027">10.224</magK>
+    <metallicity errorminus="0.09" errorplus="0.09">-0.19</metallicity>
+    <spectraltype>F4</spectraltype>
+    <temperature>6650.0</temperature>
+    <planet>
+      <name>WASP-17 b</name>
+      <name>2MASS J15595095-2803422 b</name>
+      <list>Confirmed planets</list>
+      <mass>0.48600</mass>
+      <radius>1.991</radius>
+      <period>3.73543800</period>
+      <semimajoraxis>0.051500</semimajoraxis>
+      <eccentricity errorplus="0.015" errorminus="0.018">0.028</eccentricity>
+      <inclination>86.83</inclination>
+      <transittime errorminus="0.00027" errorplus="0.00027" unit="BJD">2454577.85879</transittime>
+      <discoverymethod>Transit</discoverymethod>
+      <lastupdate>2016-09-08</lastupdate>
+      <discoveryyear>2010</discoveryyear>
+      <temperature>1517.8</temperature>
+      <istransiting>1</istransiting>
+      <periastron errorplus="2.6" errorminus="14.6">277.4</periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+      <detectionMethod>IDK</detectionMethod>
+      <lastUpdate>16/09/14</lastUpdate>
+      <discovery>2009</discovery>
+      <eccentricity errorplus="0.015000" errorminus="-0.018000">0.028000</eccentricity>
+      <periastron errorplus="14.6000" errorminus="-2.6000">-82.6000</periastron>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated WASP-17. Time Stamp: 19/11/2016 6:02:29 PM
Sources:
[WASP-17 b](http://exoplanet.eu/catalog/WASP-17_b/)
[WASP-17 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=WASP-17+b)
