### PR TITLE
Kepler-37_pcpi5

### DIFF
--- a/systems/Kepler-37.xml
+++ b/systems/Kepler-37.xml
@@ -1,94 +1,106 @@
 <system>
-	<name>Kepler-37</name>
-	<name>UGA-1785</name>
-	<rightascension>18 56 14</rightascension>
-	<declination>+44 31 05</declination>
-	<distance>66</distance>
-	<star>
-		<magB errorminus="0.04" errorplus="0.04">10.45</magB>
-		<magV errorminus="0.03" errorplus="0.03">9.77</magV>
-		<magJ errorminus="0.018" errorplus="0.018">8.356</magJ>
-		<magH errorminus="0.024" errorplus="0.024">8.000</magH>
-		<magK errorminus="0.013" errorplus="0.013">7.942</magK>
-		<name>Kepler-37</name>
-		<name>KOI-245</name>
-		<name>KIC 8478994</name>
-		<name>UGA-1785</name>
-		<mass errorminus="0.068" errorplus="0.068">0.803</mass>
-		<radius errorminus="0.026" errorplus="0.026">0.770</radius>
-		<metallicity errorminus="0.07" errorplus="0.07">-0.32</metallicity>
-		<temperature errorminus="75" errorplus="75">5417</temperature>
-		<age>6</age>
-		<planet>
-			<name>Kepler-37 b</name>
-			<name>KOI-245.03</name>
-			<name>KOI-245 b</name>
-			<name>KIC 8478994 b</name>
-			<name>UGA-1785 b</name>
-			<list>Confirmed planets</list>
-			<radius errorminus="0.0065" errorplus="0.0047">0.0270</radius>
-			<period errorminus="0.000085" errorplus="0.000058">13.367308</period>
-			<semimajoraxis errorminus="0.0011" errorplus="0.0008">0.1003</semimajoraxis>
-			<eccentricity errorminus="0.08" errorplus="0.21">0.08</eccentricity>
-			<inclination errorminus="0.53" errorplus="0.30">88.63</inclination>
-			<transittime errorminus="0.00089" errorplus="0.00034" unit="BJD">2455017.03271</transittime>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>15/06/09</lastupdate>
-			<discoveryyear>2013</discoveryyear>
-			<description>Kepler-37 b is a tiny planet, about the size of our Moon. Due to the high irradiation it has probably a rocky surface with no atmosphere or water, similar to Mercury. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-37 c</name>
-			<name>KOI-245.02</name>
-			<name>KOI-245 c</name>
-			<name>KIC 8478994 c</name>
-			<name>UGA-1785 c</name>
-			<list>Confirmed planets</list>
-			<radius errorminus="0.0074" errorplus="0.0058">0.0662</radius>
-			<period errorminus="0.000044" errorplus="0.000046">21.301886</period>
-			<semimajoraxis errorminus="0.0014" errorplus="0.0011">0.1368</semimajoraxis>
-			<eccentricity errorminus="0.09" errorplus="0.18">0.09</eccentricity>
-			<inclination errorminus="0.33" errorplus="0.19">89.07</inclination>
-			<transittime errorminus="0.00078" errorplus="0.00036" unit="BJD">2455024.83816</transittime>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>15/06/09</lastupdate>
-			<discoveryyear>2013</discoveryyear>
-			<description>Kepler-37 is a three planet system discovered by Kepler. The planet Kepler-37 c is about three quaters the size of Earth. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-37 d</name>
-			<name>KOI-245.01</name>
-			<name>KOI-245 d</name>
-			<name>KIC 8478994 d</name>
-			<name>UGA-1785 d</name>
-			<list>Confirmed planets</list>
-			<radius>0.181349</radius>
-			<period errorminus="0.000043" errorplus="0.000040">39.792187</period>
-			<semimajoraxis errorminus="0.0022" errorplus="0.0016">0.2076</semimajoraxis>
-			<eccentricity errorminus="0.1" errorplus="0.07">0.15</eccentricity>
-			<inclination errorminus="0.047" errorplus="0.043">89.335</inclination>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>15/06/09</lastupdate>
-			<transittime errorminus="0.00049" errorplus="0.00043" unit="BJD">2455008.24979</transittime>
-			<discoveryyear>2013</discoveryyear>
-			<description>Kepler-37 d is the outermost planet in a three planet system discovered by Kepler. It is twice as big as Earth and therefore the largest known planet in the system. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-37 e</name>
-			<name>KOI-245 e</name>
-			<name>KIC 8478994 e</name>
-			<name>UGA-1785 e</name>
-			<list>Confirmed planets</list>
-			<period>51.196</period>
-			<semimajoraxis>0.2508</semimajoraxis>
-			<description>The fourth planet in the Kepler-37 system was discovered by transit timing variations. Very little is known of its properties.</description>
-			<lastupdate>15/03/18</lastupdate>
-			<discoverymethod>timing</discoverymethod>
-			<discoveryyear>2014</discoveryyear>
-			<istransiting>0</istransiting>
-		</planet>
-	</star>
+  <name>Kepler-37</name>
+  <name>UGA-1785</name>
+  <rightascension>18 56 14</rightascension>
+  <declination>+44 31 05</declination>
+  <distance>66</distance>
+  <star>
+    <name>Kepler-37</name>
+    <name>KOI-245</name>
+    <name>KIC 8478994</name>
+    <name>UGA-1785</name>
+    <magB errorminus="0.04" errorplus="0.04">10.45</magB>
+    <magV errorminus="0.03" errorplus="0.03">9.77</magV>
+    <magJ errorminus="0.018" errorplus="0.018">8.356</magJ>
+    <magH errorminus="0.024" errorplus="0.024">8.000</magH>
+    <magK errorminus="0.013" errorplus="0.013">7.942</magK>
+    <mass errorminus="0.068" errorplus="0.068">0.803</mass>
+    <radius errorminus="0.026" errorplus="0.026">0.770</radius>
+    <metallicity errorminus="0.07" errorplus="0.07">-0.32</metallicity>
+    <temperature errorminus="75" errorplus="75">5417</temperature>
+    <age>6</age>
+    <planet>
+      <name>Kepler-37 b</name>
+      <name>KOI-245.03</name>
+      <name>KOI-245 b</name>
+      <name>KIC 8478994 b</name>
+      <name>UGA-1785 b</name>
+      <list>Confirmed planets</list>
+      <radius errorminus="0.0065" errorplus="0.0047">0.0270</radius>
+      <period>13.36750000</period>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorminus="0.08" errorplus="0.21">0.08</eccentricity>
+      <inclination errorminus="0.53" errorplus="0.30">88.63</inclination>
+      <transittime errorminus="0.00089" errorplus="0.00034" unit="BJD">2455017.03271</transittime>
+      <discoverymethod>Transit</discoverymethod>
+      <lastupdate>2016-10-27</lastupdate>
+      <discoveryyear>2013</discoveryyear>
+      <description>Kepler-37 b is a tiny planet, about the size of our Moon. Due to the high irradiation it has probably a rocky surface with no atmosphere or water, similar to Mercury. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
+      <istransiting>1</istransiting>
+      <mass>0.03146</mass>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-37 c</name>
+      <name>KOI-245.02</name>
+      <name>KOI-245 c</name>
+      <name>KIC 8478994 c</name>
+      <name>UGA-1785 c</name>
+      <list>Confirmed planets</list>
+      <radius errorminus="0.0074" errorplus="0.0058">0.0662</radius>
+      <period>21.30200000</period>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorminus="0.09" errorplus="0.18">0.09</eccentricity>
+      <inclination errorminus="0.33" errorplus="0.19">89.07</inclination>
+      <transittime errorminus="0.00078" errorplus="0.00036" unit="BJD">2455024.83816</transittime>
+      <discoverymethod>Transit</discoverymethod>
+      <lastupdate>2016-10-27</lastupdate>
+      <discoveryyear>2013</discoveryyear>
+      <description>Kepler-37 is a three planet system discovered by Kepler. The planet Kepler-37 c is about three quaters the size of Earth. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
+      <istransiting>1</istransiting>
+      <mass>0.03776</mass>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-37 d</name>
+      <name>KOI-245.01</name>
+      <name>KOI-245 d</name>
+      <name>KIC 8478994 d</name>
+      <name>UGA-1785 d</name>
+      <list>Confirmed planets</list>
+      <radius>0.181349</radius>
+      <period>39.79220000</period>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorminus="0.1" errorplus="0.07">0.15</eccentricity>
+      <inclination errorminus="0.047" errorplus="0.043">89.335</inclination>
+      <discoverymethod>Transit</discoverymethod>
+      <lastupdate>2016-10-27</lastupdate>
+      <transittime errorminus="0.00049" errorplus="0.00043" unit="BJD">2455008.24979</transittime>
+      <discoveryyear>2013</discoveryyear>
+      <description>Kepler-37 d is the outermost planet in a three planet system discovered by Kepler. It is twice as big as Earth and therefore the largest known planet in the system. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
+      <istransiting>1</istransiting>
+      <mass>0.03839</mass>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-37 e</name>
+      <name>KOI-245 e</name>
+      <name>KIC 8478994 e</name>
+      <name>UGA-1785 e</name>
+      <list>Confirmed planets</list>
+      <period>51.196</period>
+      <semimajoraxis>0.2508</semimajoraxis>
+      <description>The fourth planet in the Kepler-37 system was discovered by transit timing variations. Very little is known of its properties.</description>
+      <lastupdate>15/03/18</lastupdate>
+      <discoverymethod>timing</discoverymethod>
+      <discoveryyear>2014</discoveryyear>
+      <istransiting>0</istransiting>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-37. Time Stamp: 19/11/2016 6:02:32 PM
Sources:
[Kepler-37 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-37+d)
