### PR TITLE
Kepler-48_rgrxg

### DIFF
--- a/systems/Kepler-48.xml
+++ b/systems/Kepler-48.xml
@@ -1,77 +1,85 @@
 <system>
-	<name>Kepler-48</name>
-	<rightascension>19 56 33</rightascension>
-	<declination>+40 56 56</declination>
-	<distance>313.14</distance>
-	<star>
-		<name>Kepler-48</name>
-		<name>KOI-148</name>
-		<name>KIC 5735762</name>
-		<temperature>5190.0</temperature>
-		<magJ errorminus="0.024" errorplus="0.024">11.702</magJ>
-		<magH errorminus="0.026" errorplus="0.026">11.292</magH>
-		<magK errorminus="0.023" errorplus="0.023">11.221</magK>
-		<mass>0.89</mass>
-		<radius>0.89</radius>
-		<planet>
-			<name>Kepler-48 b</name>
-			<name>KOI-148.01</name>
-			<name>KOI-148 b</name>
-			<name>KIC 5735762 b</name>
-			<list>Confirmed planets</list>
-			<mass>0.015079</mass>
-			<radius>0.195019</radius>
-			<period>4.7779803</period>
-			<transittime errorminus="0.001" errorplus="0.001" unit="BJD">2455057.06301</transittime>
-			<description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 4.78 days for 2.8412 hours. Periodic transit timing variations confirm its planetary nature.</description>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>12/08/19</lastupdate>
-			<discoveryyear>2012</discoveryyear>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-48 c</name>
-			<name>KOI-148.02</name>
-			<name>KOI-148 c</name>
-			<name>KIC 5735762 c</name>
-			<list>Confirmed planets</list>
-			<mass>0.033219</mass>
-			<radius>0.286149</radius>
-			<period>9.6739283</period>
-			<transittime errorminus="0.00077" errorplus="0.00077" unit="BJD">2455058.33981</transittime>
-			<description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 9.67 days for 3.5027 hours. Periodic transit timing variations confirm its planetary nature.</description>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>12/08/19</lastupdate>
-			<discoveryyear>2012</discoveryyear>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-48 d</name>
-			<name>KOI-148.03</name>
-			<name>KOI-148 d</name>
-			<name>KIC 5735762 d</name>
-			<period>42.8961</period>
-			<radius errorminus="0.010024" errorplus="0.010024">0.185906</radius>
-			<mass errorminus="0.014470" errorplus="0.014470">0.024945</mass>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-48 e</name>
-			<name>KOI-148.10</name>
-			<name>KOI-148 e</name>
-			<name>KIC 5735762 e</name>
-			<period errorminus="8" errorplus="8">982</period>
-			<mass errorminus="0.078643" errorplus="0.078643">2.066725</mass>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered during a radial velocity follow up of stars observed by Kepler which host planet candidates. Although other planets in this system are transiting, this one is not.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>RV</discoverymethod>
-		</planet>
-	</star>
+  <name>Kepler-48</name>
+  <rightascension>19 56 33</rightascension>
+  <declination>+40 56 56</declination>
+  <distance>313.14</distance>
+  <star>
+    <name>Kepler-48</name>
+    <name>KOI-148</name>
+    <name>KIC 5735762</name>
+    <temperature>5190.0</temperature>
+    <magJ errorminus="0.024" errorplus="0.024">11.702</magJ>
+    <magH errorminus="0.026" errorplus="0.026">11.292</magH>
+    <magK errorminus="0.023" errorplus="0.023">11.221</magK>
+    <mass>0.89</mass>
+    <radius>0.89</radius>
+    <planet>
+      <name>Kepler-48 b</name>
+      <name>KOI-148.01</name>
+      <name>KOI-148 b</name>
+      <name>KIC 5735762 b</name>
+      <list>Confirmed planets</list>
+      <mass>0.01240</mass>
+      <radius>0.195019</radius>
+      <period>4.77800000</period>
+      <transittime errorminus="0.001" errorplus="0.001" unit="BJD">2455057.06301</transittime>
+      <description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 4.78 days for 2.8412 hours. Periodic transit timing variations confirm its planetary nature.</description>
+      <discoverymethod>Transit</discoverymethod>
+      <lastupdate>2016-10-27</lastupdate>
+      <discoveryyear>2013</discoveryyear>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-48 c</name>
+      <name>KOI-148.02</name>
+      <name>KOI-148 c</name>
+      <name>KIC 5735762 c</name>
+      <list>Confirmed planets</list>
+      <mass>0.04597</mass>
+      <radius>0.286149</radius>
+      <period>9.67395000</period>
+      <transittime errorminus="0.00077" errorplus="0.00077" unit="BJD">2455058.33981</transittime>
+      <description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 9.67 days for 3.5027 hours. Periodic transit timing variations confirm its planetary nature.</description>
+      <discoverymethod>Transit</discoverymethod>
+      <lastupdate>2016-10-27</lastupdate>
+      <discoveryyear>2013</discoveryyear>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-48 d</name>
+      <name>KOI-148.03</name>
+      <name>KOI-148 d</name>
+      <name>KIC 5735762 d</name>
+      <period>42.8961</period>
+      <radius errorminus="0.010024" errorplus="0.010024">0.185906</radius>
+      <mass errorminus="0.014470" errorplus="0.014470">0.024945</mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>transit</discoverymethod>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-48 e</name>
+      <name>KOI-148.10</name>
+      <name>KOI-148 e</name>
+      <name>KIC 5735762 e</name>
+      <period errorminus="8" errorplus="8">982</period>
+      <mass errorminus="0.078643" errorplus="0.078643">2.066725</mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered during a radial velocity follow up of stars observed by Kepler which host planet candidates. Although other planets in this system are transiting, this one is not.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>RV</discoverymethod>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-48. Time Stamp: 19/11/2016 6:02:33 PM
Sources:
[Kepler-48 c](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-48+b)
