### PR TITLE
Kepler-68_hvo13

### DIFF
--- a/systems/Kepler-68.xml
+++ b/systems/Kepler-68.xml
@@ -1,106 +1,103 @@
 <system>
-	<name>Kepler-68</name>
-	<rightascension>19 24 07.7644</rightascension>
-	<declination>+49 02 24.957</declination>
-	<distance errorminus="10" errorplus="10">135</distance>
-	<binary>
-		<name>Kepler-68</name>
-		<name>KOI-246</name>
-		<name>KIC 11295426</name>
-		<separation errorminus="0.030" errorplus="0.030" unit="arcsec">10.979</separation>
-		<separation errorminus="110" errorplus="110" unit="AU">1482</separation>
-		<positionangle errorminus="0.18" errorplus="0.18">145.43</positionangle>
-		<star>
-			<name>Kepler-68 A</name>
-			<name>KOI-246 A</name>
-			<name>KIC 11295426 A</name>
-			<name>2MASS J19240775+4902249</name>
-			<name>TYC 3551-189-1</name>
-			<mass errorminus="0.051" errorplus="0.051">1.079</mass>
-			<radius errorminus="0.019" errorplus="0.019">1.243</radius>
-			<temperature errorminus="74" errorplus="74">5793</temperature>
-			<magV errorminus="0.001" errorplus="0.001">9.997</magV>
-			<magB errorminus="0.04" errorplus="0.04">10.73</magB>
-			<magJ errorminus="0.046" errorplus="0.046">8.975</magJ>
-			<magH errorminus="0.029" errorplus="0.029">8.662</magH>
-			<magK errorminus="0.022" errorplus="0.022">8.588</magK>
-			<age errorminus="1.7" errorplus="1.7">6.3</age>
-			<metallicity errorminus="0.074" errorplus="0.074">0.12</metallicity>
-			<spectraltype>G</spectraltype>
-			<planet>
-				<name>Kepler-68 b</name>
-				<name>Kepler-68 A b</name>
-				<name>KIC 11295426 b</name>
-				<name>KIC 11295426 A b</name>
-				<name>2MASS J19240775+4902249 b</name>
-				<name>KOI-246.01</name>
-				<name>KOI-246 b</name>
-				<name>KOI-246 A b</name>
-				<list>Confirmed planets</list>
-				<mass errorminus="0.007" errorplus="0.008">0.026</mass>
-				<radius errorminus="0.008" errorplus="0.005">0.206</radius>
-				<temperature errorminus="90" errorplus="90">1280</temperature>
-				<period errorminus="0.000004" errorplus="0.000004">5.398763</period>
-				<semimajoraxis errorminus="0.00056" errorplus="0.00056">0.06170</semimajoraxis>
-				<eccentricity errorminus="0.02" errorplus="0.13">0.02</eccentricity>
-				<inclination errorminus="0.90" errorplus="0.90">87.60</inclination>
-				<transittime errorminus="0.00042" errorplus="0.00042" unit="BJD">2455006.85729</transittime>
-				<discoverymethod>transit</discoverymethod>
-				<lastupdate>15/06/09</lastupdate>
-				<discoveryyear>2013</discoveryyear>
-				<description>The inner two planets in the Kepler-68 system are transiting. The outer planet was discovered by radial velocity follow-up observation. Kepler-68 b has a density intermediate between that of ice giants and Earth.</description>
-				<istransiting>1</istransiting>
-				<list>Planets in binary systems, S-type</list>
-			</planet>
-			<planet>
-				<name>Kepler-68 c</name>
-				<name>Kepler-68 A c</name>
-				<name>KIC 11295426 c</name>
-				<name>KIC 11295426 A c</name>
-				<name>2MASS J19240775+4902249 c</name>
-				<name>KOI-246.02</name>
-				<name>KOI-246 c</name>
-				<name>KOI-246 A c</name>
-				<list>Confirmed planets</list>
-				<mass errorminus="0.011" errorplus="0.008">0.015</mass>
-				<radius errorminus="0.0037" errorplus="0.0033">0.0850</radius>
-				<period errorminus="0.000072" errorplus="0.000072">9.605085</period>
-				<semimajoraxis errorminus="0.00082" errorplus="0.00082">0.09059</semimajoraxis>
-				<inclination errorminus="0.41" errorplus="0.41">86.93</inclination>
-				<transittime errorminus="0.0041" errorplus="0.0041" unit="BJD">2454969.3805</transittime>
-				<discoverymethod>transit</discoverymethod>
-				<lastupdate>15/06/09</lastupdate>
-				<discoveryyear>2013</discoveryyear>
-				<description>The inner two planets in the Kepler-68 system are transiting. The outer planet was discovered by radial velocity follow-up observation. Kepler-68 c is Earth-sized.</description>
-				<istransiting>1</istransiting>
-				<list>Planets in binary systems, S-type</list>
-			</planet>
-			<planet>
-				<name>Kepler-68 d</name>
-				<name>Kepler-68 A d</name>
-				<name>KIC 11295426 d</name>
-				<name>KIC 11295426 A d</name>
-				<name>2MASS J19240775+4902249 d</name>
-				<name>KOI-246.20</name>
-				<name>KOI-246 d</name>
-				<name>KOI-246 A d</name>
-				<list>Confirmed planets</list>
-				<mass errorminus="0.035" errorplus="0.035" type="msini">0.947</mass>
-				<period errorminus="15" errorplus="15">580</period>
-				<semimajoraxis errorminus="0.03" errorplus="0.03">1.40</semimajoraxis>
-				<eccentricity errorminus="0.05" errorplus="0.05">0.18</eccentricity>
-				<discoverymethod>RV</discoverymethod>
-				<lastupdate>15/06/09</lastupdate>
-				<discoveryyear>2013</discoveryyear>
-				<description>The inner two planets in the Kepler-68 system are transiting. The outer planet, Kepler-68 d, was discovered by radial velocity follow-up observation. The mass is therefore a lower limit.</description>
-				<list>Planets in binary systems, S-type</list>
-			</planet>
-		</star>
-		<star>
-			<name>Kepler-68 B</name>
-			<name>KOI-246 B</name>
-			<name>KIC 11295426 B</name>
-			<mass errorminus="0.010" errorplus="0.013">0.175</mass>
-		</star>
-	</binary>
+  <name>Kepler-68</name>
+  <rightascension>19 24 07.7644</rightascension>
+  <declination>+49 02 24.957</declination>
+  <distance errorminus="10" errorplus="10">135</distance>
+  <binary>
+    <name>Kepler-68</name>
+    <name>KOI-246</name>
+    <name>KIC 11295426</name>
+    <separation errorminus="0.030" errorplus="0.030" unit="arcsec">10.979</separation>
+    <separation errorminus="110" errorplus="110" unit="AU">1482</separation>
+    <positionangle errorminus="0.18" errorplus="0.18">145.43</positionangle>
+    <star>
+      <name>Kepler-68 A</name>
+      <name>KOI-246 A</name>
+      <name>KIC 11295426 A</name>
+      <name>2MASS J19240775+4902249</name>
+      <name>TYC 3551-189-1</name>
+      <mass errorminus="0.051" errorplus="0.051">1.079</mass>
+      <radius errorminus="0.019" errorplus="0.019">1.243</radius>
+      <temperature errorminus="74" errorplus="74">5793</temperature>
+      <magV errorminus="0.001" errorplus="0.001">9.997</magV>
+      <magB errorminus="0.04" errorplus="0.04">10.73</magB>
+      <magJ errorminus="0.046" errorplus="0.046">8.975</magJ>
+      <magH errorminus="0.029" errorplus="0.029">8.662</magH>
+      <magK errorminus="0.022" errorplus="0.022">8.588</magK>
+      <age errorminus="1.7" errorplus="1.7">6.3</age>
+      <metallicity errorminus="0.074" errorplus="0.074">0.12</metallicity>
+      <spectraltype>G</spectraltype>
+      <planet>
+        <name>Kepler-68 b</name>
+        <name>Kepler-68 A b</name>
+        <name>KIC 11295426 b</name>
+        <name>KIC 11295426 A b</name>
+        <name>2MASS J19240775+4902249 b</name>
+        <name>KOI-246.01</name>
+        <name>KOI-246 b</name>
+        <name>KOI-246 A b</name>
+        <list>Planets in binary systems, S-type</list>
+        <mass errorminus="0.007" errorplus="0.008">0.026</mass>
+        <radius errorminus="0.008" errorplus="0.005">0.206</radius>
+        <temperature errorminus="90" errorplus="90">1280</temperature>
+        <period errorminus="0.000004" errorplus="0.000004">5.398763</period>
+        <semimajoraxis errorminus="0.00056" errorplus="0.00056">0.06170</semimajoraxis>
+        <eccentricity errorminus="0.02" errorplus="0.13">0.02</eccentricity>
+        <inclination errorminus="0.90" errorplus="0.90">87.60</inclination>
+        <transittime errorminus="0.00042" errorplus="0.00042" unit="BJD">2455006.85729</transittime>
+        <discoverymethod>transit</discoverymethod>
+        <lastupdate>15/06/09</lastupdate>
+        <discoveryyear>2013</discoveryyear>
+        <description>The inner two planets in the Kepler-68 system are transiting. The outer planet was discovered by radial velocity follow-up observation. Kepler-68 b has a density intermediate between that of ice giants and Earth.</description>
+        <istransiting>1</istransiting>
+      </planet>
+      <planet>
+        <name>Kepler-68 c</name>
+        <name>Kepler-68 A c</name>
+        <name>KIC 11295426 c</name>
+        <name>KIC 11295426 A c</name>
+        <name>2MASS J19240775+4902249 c</name>
+        <name>KOI-246.02</name>
+        <name>KOI-246 c</name>
+        <name>KOI-246 A c</name>
+        <list>Planets in binary systems, S-type</list>
+        <mass errorminus="0.011" errorplus="0.008">0.015</mass>
+        <radius errorminus="0.0037" errorplus="0.0033">0.0850</radius>
+        <period errorminus="0.000072" errorplus="0.000072">9.605085</period>
+        <semimajoraxis errorminus="0.00082" errorplus="0.00082">0.09059</semimajoraxis>
+        <inclination errorminus="0.41" errorplus="0.41">86.93</inclination>
+        <transittime errorminus="0.0041" errorplus="0.0041" unit="BJD">2454969.3805</transittime>
+        <discoverymethod>transit</discoverymethod>
+        <lastupdate>15/06/09</lastupdate>
+        <discoveryyear>2013</discoveryyear>
+        <description>The inner two planets in the Kepler-68 system are transiting. The outer planet was discovered by radial velocity follow-up observation. Kepler-68 c is Earth-sized.</description>
+        <istransiting>1</istransiting>
+      </planet>
+      <planet>
+        <name>Kepler-68 d</name>
+        <name>Kepler-68 A d</name>
+        <name>KIC 11295426 d</name>
+        <name>KIC 11295426 A d</name>
+        <name>2MASS J19240775+4902249 d</name>
+        <name>KOI-246.20</name>
+        <name>KOI-246 d</name>
+        <name>KOI-246 A d</name>
+        <list>Planets in binary systems, S-type</list>
+        <mass errorminus="0.035" errorplus="0.035" type="msini">0.947</mass>
+        <period errorminus="15" errorplus="15">580</period>
+        <semimajoraxis errorminus="0.03" errorplus="0.03">1.40</semimajoraxis>
+        <eccentricity errorminus="0.05" errorplus="0.05">0.18</eccentricity>
+        <discoverymethod>RV</discoverymethod>
+        <lastupdate>15/06/09</lastupdate>
+        <discoveryyear>2013</discoveryyear>
+        <description>The inner two planets in the Kepler-68 system are transiting. The outer planet, Kepler-68 d, was discovered by radial velocity follow-up observation. The mass is therefore a lower limit.</description>
+      </planet>
+    </star>
+    <star>
+      <name>Kepler-68 B</name>
+      <name>KOI-246 B</name>
+      <name>KIC 11295426 B</name>
+      <mass errorminus="0.010" errorplus="0.013">0.175</mass>
+    </star>
+  </binary>
 </system>


### PR DESCRIPTION
Updated Kepler-68. Time Stamp: 19/11/2016 6:02:33 PM
Sources:
[Kepler-68 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-68+d)
