### PR TITLE
Kepler-100_py6nb

### DIFF
--- a/systems/Kepler-100.xml
+++ b/systems/Kepler-100.xml
@@ -1,79 +1,85 @@
 <system>
-	<name>Kepler-100</name>
-	<name>KOI-41</name>
-	<name>KIC 6521045</name>
-	<rightascension>19 25 32</rightascension>
-	<declination>+41 59 24</declination>
-	<distance>296.6</distance>
-	<star>
-		<magB errorminus="0.11" errorplus="0.11">11.86</magB>
-		<magV errorminus="0.07" errorplus="0.07">11.06</magV>
-		<magJ errorminus="0.021" errorplus="0.021">10.081</magJ>
-		<magH errorminus="0.017" errorplus="0.017">9.804</magH>
-		<magK errorminus="0.014" errorplus="0.014">9.768</magK>
-		<name>Kepler-100</name>
-		<name>KOI-41</name>
-		<name>KIC 6521045</name>
-		<temperature errorminus="75" errorplus="75">5825</temperature>
-		<metallicity errorminus="0.10" errorplus="0.10">0.02</metallicity>
-		<mass errorminus="0.06" errorplus="0.06">1.08</mass>
-		<radius errorminus="0.04" errorplus="0.04">1.49</radius>
-		<age>6.46</age>
-		<planet>
-			<name>Kepler-100 c</name>
-			<name>KOI-41.01</name>
-			<name>KOI-41 c</name>
-			<name>KIC 6521045 c</name>
-			<period>12.8159</period>
-			<radius errorminus="0.004557" errorplus="0.004557">0.200487</radius>
-			<mass upperlimit="0.0222" />
-			<transittime unit="BJD">2454955.94713</transittime>
-			<semimajoraxis errorminus="0.002" errorplus="0.002">0.110</semimajoraxis>
-			<inclination errorminus="0.1" errorplus="0.1">89.8</inclination>
-			<eccentricity errorminus="0.01" errorplus="0.15">0.02</eccentricity>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-100 b</name>
-			<name>KOI-41.02</name>
-			<name>KOI-41 b</name>
-			<name>KIC 6521045 b</name>
-			<period>6.88705</period>
-			<radius errorminus="0.003645" errorplus="0.003645">0.120292</radius>
-			<mass errorminus="0.010" errorplus="0.010">0.0231</mass>
-			<transittime unit="BJD">2454966.17797</transittime>
-			<semimajoraxis errorminus="0.0013" errorplus="0.0013">0.0727</semimajoraxis>
-			<inclination errorminus="0.1" errorplus="0.1">87.1</inclination>
-			<eccentricity errorminus="0.13" errorplus="0.27">0.13</eccentricity>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-100 d</name>
-			<name>KOI-41.03</name>
-			<name>KOI-41 d</name>
-			<name>KIC 6521045 d</name>
-			<period>35.3331</period>
-			<radius errorminus="0.004557" errorplus="0.004557">0.146720</radius>
-			<mass upperlimit="0.0094" />
-			<transittime unit="BJD">2454966.17797</transittime>
-			<semimajoraxis errorminus="0.004" errorplus="0.004">0.216</semimajoraxis>
-			<inclination errorminus="0.05" errorplus="0.05">88.62</inclination>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-	</star>
+  <name>Kepler-100</name>
+  <name>KOI-41</name>
+  <name>KIC 6521045</name>
+  <rightascension>19 25 32</rightascension>
+  <declination>+41 59 24</declination>
+  <distance>296.6</distance>
+  <star>
+    <name>Kepler-100</name>
+    <name>KOI-41</name>
+    <name>KIC 6521045</name>
+    <magB errorminus="0.11" errorplus="0.11">11.86</magB>
+    <magV errorminus="0.07" errorplus="0.07">11.06</magV>
+    <magJ errorminus="0.021" errorplus="0.021">10.081</magJ>
+    <magH errorminus="0.017" errorplus="0.017">9.804</magH>
+    <magK errorminus="0.014" errorplus="0.014">9.768</magK>
+    <temperature errorminus="75" errorplus="75">5825</temperature>
+    <metallicity errorminus="0.10" errorplus="0.10">0.02</metallicity>
+    <mass errorminus="0.06" errorplus="0.06">1.08</mass>
+    <radius errorminus="0.04" errorplus="0.04">1.49</radius>
+    <age>6.46</age>
+    <planet>
+      <name>Kepler-100 c</name>
+      <name>KOI-41.01</name>
+      <name>KOI-41 c</name>
+      <name>KIC 6521045 c</name>
+      <period>12.81590000</period>
+      <radius errorminus="0.004557" errorplus="0.004557">0.200487</radius>
+      <mass></mass>
+      <transittime unit="BJD">2454955.94713</transittime>
+      <semimajoraxis></semimajoraxis>
+      <inclination errorminus="0.1" errorplus="0.1">89.8</inclination>
+      <eccentricity errorminus="0.01" errorplus="0.15">0.02</eccentricity>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-100 b</name>
+      <name>KOI-41.02</name>
+      <name>KOI-41 b</name>
+      <name>KIC 6521045 b</name>
+      <period>6.88705</period>
+      <radius errorminus="0.003645" errorplus="0.003645">0.120292</radius>
+      <mass errorminus="0.010" errorplus="0.010">0.0231</mass>
+      <transittime unit="BJD">2454966.17797</transittime>
+      <semimajoraxis errorminus="0.0013" errorplus="0.0013">0.0727</semimajoraxis>
+      <inclination errorminus="0.1" errorplus="0.1">87.1</inclination>
+      <eccentricity errorminus="0.13" errorplus="0.27">0.13</eccentricity>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>transit</discoverymethod>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-100 d</name>
+      <name>KOI-41.03</name>
+      <name>KOI-41 d</name>
+      <name>KIC 6521045 d</name>
+      <period>35.33310000</period>
+      <radius errorminus="0.004557" errorplus="0.004557">0.146720</radius>
+      <mass></mass>
+      <transittime unit="BJD">2454966.17797</transittime>
+      <semimajoraxis></semimajoraxis>
+      <inclination errorminus="0.05" errorplus="0.05">88.62</inclination>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-100. Time Stamp: 19/11/2016 6:02:34 PM
Sources:
[Kepler-100 c](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-100+d)
