### PR TITLE
Kepler-102_9p5do

### DIFF
--- a/systems/Kepler-102.xml
+++ b/systems/Kepler-102.xml
@@ -1,98 +1,110 @@
 <system>
-	<name>Kepler-102</name>
-	<name>KOI-82</name>
-	<name>KIC 10187017</name>
-	<rightascension>18 45 55</rightascension>
-	<declination>+47 12 28</declination>
-	<distance>119.3</distance>
-	<star>
-		<magB errorminus="0.24" errorplus="0.24">12.58</magB>
-		<magV errorminus="0.19" errorplus="0.19">12.07</magV>
-		<magJ errorminus="0.023" errorplus="0.023">9.984</magJ>
-		<magH errorminus="0.018" errorplus="0.018">9.446</magH>
-		<magK errorminus="0.011" errorplus="0.011">9.351</magK>
-		<name>Kepler-102</name>
-		<name>KOI-82</name>
-		<name>KIC 10187017</name>
-		<temperature errorminus="74" errorplus="74">4903</temperature>
-		<metallicity errorminus="0.07" errorplus="0.07">0.08</metallicity>
-		<mass errorminus="0.06" errorplus="0.06">0.80</mass>
-		<radius errorminus="0.02" errorplus="0.02">0.74</radius>
-		<age>1.41</age>
-		<planet>
-			<name>Kepler-102 e</name>
-			<name>KOI-82.01</name>
-			<name>KOI-82 e</name>
-			<name>KIC 10187017 e</name>
-			<period>16.1457</period>
-			<radius errorminus="0.006379" errorplus="0.006379">0.202309</radius>
-			<list>Confirmed planets</list>
-			<mass errorminus="0.006291" errorplus="0.006291">0.028091</mass>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-102 d</name>
-			<name>KOI-82.02</name>
-			<name>KOI-82 d</name>
-			<name>KIC 10187017 d</name>
-			<period>10.3117</period>
-			<radius errorminus="0.003645" errorplus="0.003645">0.107534</radius>
-			<mass errorminus="0.005662" errorplus="0.005662">0.011954</mass>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-102 f</name>
-			<name>KOI-82.03</name>
-			<name>KOI-82 f</name>
-			<name>KIC 10187017 f</name>
-			<period>27.4536</period>
-			<radius errorminus="0.002734" errorplus="0.002734">0.080195</radius>
-			<mass upperlimit="0.016358" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-102 c</name>
-			<name>KOI-82.04</name>
-			<name>KOI-82 c</name>
-			<name>KIC 10187017 c</name>
-			<period>7.07142</period>
-			<radius errorminus="0.001823" errorplus="0.001823">0.052856</radius>
-			<mass upperlimit="0.009437" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-102 b</name>
-			<name>KOI-82.05</name>
-			<name>KOI-82 b</name>
-			<name>KIC 10187017 b</name>
-			<period>5.28696</period>
-			<radius errorminus="0.001823" errorplus="0.001823">0.042831</radius>
-			<mass upperlimit="0.013527" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-	</star>
+  <name>Kepler-102</name>
+  <name>KOI-82</name>
+  <name>KIC 10187017</name>
+  <rightascension>18 45 55</rightascension>
+  <declination>+47 12 28</declination>
+  <distance>119.3</distance>
+  <star>
+    <name>Kepler-102</name>
+    <name>KOI-82</name>
+    <name>KIC 10187017</name>
+    <magB errorminus="0.24" errorplus="0.24">12.58</magB>
+    <magV errorminus="0.19" errorplus="0.19">12.07</magV>
+    <magJ errorminus="0.023" errorplus="0.023">9.984</magJ>
+    <magH errorminus="0.018" errorplus="0.018">9.446</magH>
+    <magK errorminus="0.011" errorplus="0.011">9.351</magK>
+    <temperature errorminus="74" errorplus="74">4903</temperature>
+    <metallicity errorminus="0.07" errorplus="0.07">0.08</metallicity>
+    <mass errorminus="0.06" errorplus="0.06">0.80</mass>
+    <radius errorminus="0.02" errorplus="0.02">0.74</radius>
+    <age>1.41</age>
+    <planet>
+      <name>Kepler-102 e</name>
+      <name>KOI-82.01</name>
+      <name>KOI-82 e</name>
+      <name>KIC 10187017 e</name>
+      <period>16.1457</period>
+      <radius errorminus="0.006379" errorplus="0.006379">0.202309</radius>
+      <list>Confirmed planets</list>
+      <mass errorminus="0.006291" errorplus="0.006291">0.028091</mass>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>transit</discoverymethod>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-102 d</name>
+      <name>KOI-82.02</name>
+      <name>KOI-82 d</name>
+      <name>KIC 10187017 d</name>
+      <period>10.3117</period>
+      <radius errorminus="0.003645" errorplus="0.003645">0.107534</radius>
+      <mass errorminus="0.005662" errorplus="0.005662">0.011954</mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>transit</discoverymethod>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-102 f</name>
+      <name>KOI-82.03</name>
+      <name>KOI-82 f</name>
+      <name>KIC 10187017 f</name>
+      <period>27.45360000</period>
+      <radius errorminus="0.002734" errorplus="0.002734">0.080195</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-102 c</name>
+      <name>KOI-82.04</name>
+      <name>KOI-82 c</name>
+      <name>KIC 10187017 c</name>
+      <period>7.07142000</period>
+      <radius errorminus="0.001823" errorplus="0.001823">0.052856</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-102 b</name>
+      <name>KOI-82.05</name>
+      <name>KOI-82 b</name>
+      <name>KIC 10187017 b</name>
+      <period>5.28696000</period>
+      <radius errorminus="0.001823" errorplus="0.001823">0.042831</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-102. Time Stamp: 19/11/2016 6:02:35 PM
Sources:
[Kepler-102 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-102+f)
