### PR TITLE
Kepler-106_5nvxg

### DIFF
--- a/systems/Kepler-106.xml
+++ b/systems/Kepler-106.xml
@@ -1,83 +1,91 @@
 <system>
-	<name>Kepler-106</name>
-	<name>KOI-116</name>
-	<name>KIC 8395660</name>
-	<rightascension>20 03 27</rightascension>
-	<declination>+44 20 15</declination>
-	<distance>453.9</distance>
-	<star>
-		<magB>13.68</magB>
-		<magV>12.98</magV>
-		<magJ errorminus="0.020" errorplus="0.020">11.752</magJ>
-		<magH errorminus="0.023" errorplus="0.023">11.494</magH>
-		<magK errorminus="0.018" errorplus="0.018">11.431</magK>
-		<name>Kepler-106</name>
-		<name>KOI-116</name>
-		<name>KIC 8395660</name>
-		<temperature errorminus="114" errorplus="114">5858</temperature>
-		<metallicity errorminus="0.11" errorplus="0.11">-0.12</metallicity>
-		<mass errorminus="0.06" errorplus="0.06">1.00</mass>
-		<radius errorminus="0.17" errorplus="0.17">1.04</radius>
-		<age>4.83</age>
-		<planet>
-			<name>Kepler-106 c</name>
-			<name>KOI-116.01</name>
-			<name>KOI-116 c</name>
-			<name>KIC 8395660 c</name>
-			<period>13.5708</period>
-			<radius errorminus="0.029162" errorplus="0.029162">0.227826</radius>
-			<mass errorminus="0.010066" errorplus="0.010066">0.032841</mass>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-106 e</name>
-			<name>KOI-116.02</name>
-			<name>KOI-116 e</name>
-			<name>KIC 8395660 e</name>
-			<period>43.8445</period>
-			<radius errorminus="0.030073" errorplus="0.030073">0.233294</radius>
-			<list>Confirmed planets</list>
-			<mass errorminus="0.018245" errorplus="0.018245">0.035137</mass>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-106 b</name>
-			<name>KOI-116.03</name>
-			<name>KOI-116 b</name>
-			<name>KIC 8395660 b</name>
-			<period>6.16486</period>
-			<radius errorminus="0.010024" errorplus="0.010024">0.074727</radius>
-			<mass upperlimit="0.016672" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-106 d</name>
-			<name>KOI-116.04</name>
-			<name>KOI-116 d</name>
-			<name>KIC 8395660 d</name>
-			<period>23.9802</period>
-			<radius errorminus="0.011847" errorplus="0.011847">0.086574</radius>
-			<mass upperlimit="0.025480" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-	</star>
+  <name>Kepler-106</name>
+  <name>KOI-116</name>
+  <name>KIC 8395660</name>
+  <rightascension>20 03 27</rightascension>
+  <declination>+44 20 15</declination>
+  <distance>453.9</distance>
+  <star>
+    <name>Kepler-106</name>
+    <name>KOI-116</name>
+    <name>KIC 8395660</name>
+    <magB>13.68</magB>
+    <magV>12.98</magV>
+    <magJ errorminus="0.020" errorplus="0.020">11.752</magJ>
+    <magH errorminus="0.023" errorplus="0.023">11.494</magH>
+    <magK errorminus="0.018" errorplus="0.018">11.431</magK>
+    <temperature errorminus="114" errorplus="114">5858</temperature>
+    <metallicity errorminus="0.11" errorplus="0.11">-0.12</metallicity>
+    <mass errorminus="0.06" errorplus="0.06">1.00</mass>
+    <radius errorminus="0.17" errorplus="0.17">1.04</radius>
+    <age>4.83</age>
+    <planet>
+      <name>Kepler-106 c</name>
+      <name>KOI-116.01</name>
+      <name>KOI-116 c</name>
+      <name>KIC 8395660 c</name>
+      <period>13.5708</period>
+      <radius errorminus="0.029162" errorplus="0.029162">0.227826</radius>
+      <mass errorminus="0.010066" errorplus="0.010066">0.032841</mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>transit</discoverymethod>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-106 e</name>
+      <name>KOI-116.02</name>
+      <name>KOI-116 e</name>
+      <name>KIC 8395660 e</name>
+      <period>43.8445</period>
+      <radius errorminus="0.030073" errorplus="0.030073">0.233294</radius>
+      <list>Confirmed planets</list>
+      <mass errorminus="0.018245" errorplus="0.018245">0.035137</mass>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>transit</discoverymethod>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-106 b</name>
+      <name>KOI-116.03</name>
+      <name>KOI-116 b</name>
+      <name>KIC 8395660 b</name>
+      <period>6.16486000</period>
+      <radius errorminus="0.010024" errorplus="0.010024">0.074727</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-106 d</name>
+      <name>KOI-116.04</name>
+      <name>KOI-116 d</name>
+      <name>KIC 8395660 d</name>
+      <period>23.98020000</period>
+      <radius errorminus="0.011847" errorplus="0.011847">0.086574</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-106. Time Stamp: 19/11/2016 6:02:36 PM
Sources:
[Kepler-106 d](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-106+b)
