### PR TITLE
Kepler-113_bpni2

### DIFF
--- a/systems/Kepler-113.xml
+++ b/systems/Kepler-113.xml
@@ -1,51 +1,55 @@
 <system>
-	<name>Kepler-113</name>
-	<name>KOI-153</name>
-	<name>KIC 12252424</name>
-	<rightascension>19 11 59</rightascension>
-	<declination>+50 56 39</declination>
-	<distance>255.9</distance>
-	<star>
-		<magJ errorminus="0.027" errorplus="0.027">11.886</magJ>
-		<magH errorminus="0.03" errorplus="0.03">11.36</magH>
-		<magK errorminus="0.023" errorplus="0.023">11.255</magK>
-		<name>Kepler-113</name>
-		<name>KOI-153</name>
-		<name>KIC 12252424</name>
-		<temperature errorminus="74" errorplus="74">4725</temperature>
-		<metallicity errorminus="0.07" errorplus="0.07">0.05</metallicity>
-		<mass errorminus="0.06" errorplus="0.06">0.75</mass>
-		<radius errorminus="0.02" errorplus="0.02">0.69</radius>
-		<age>6.89</age>
-		<planet>
-			<name>Kepler-113 c</name>
-			<name>KOI-153.01</name>
-			<name>KOI-153 c</name>
-			<name>KIC 12252424 c</name>
-			<period>8.92507</period>
-			<radius errorminus="0.005468" errorplus="0.005468">0.198664</radius>
-			<mass upperlimit="0.027368" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-113 b</name>
-			<name>KOI-153.02</name>
-			<name>KOI-153 b</name>
-			<name>KIC 12252424 b</name>
-			<period>4.75400</period>
-			<radius errorminus="0.004557" errorplus="0.004557">0.165857</radius>
-			<list>Confirmed planets</list>
-			<mass errorminus="0.013212" errorplus="0.013212">0.036805</mass>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-	</star>
+  <name>Kepler-113</name>
+  <name>KOI-153</name>
+  <name>KIC 12252424</name>
+  <rightascension>19 11 59</rightascension>
+  <declination>+50 56 39</declination>
+  <distance>255.9</distance>
+  <star>
+    <name>Kepler-113</name>
+    <name>KOI-153</name>
+    <name>KIC 12252424</name>
+    <magJ errorminus="0.027" errorplus="0.027">11.886</magJ>
+    <magH errorminus="0.03" errorplus="0.03">11.36</magH>
+    <magK errorminus="0.023" errorplus="0.023">11.255</magK>
+    <temperature errorminus="74" errorplus="74">4725</temperature>
+    <metallicity errorminus="0.07" errorplus="0.07">0.05</metallicity>
+    <mass errorminus="0.06" errorplus="0.06">0.75</mass>
+    <radius errorminus="0.02" errorplus="0.02">0.69</radius>
+    <age>6.89</age>
+    <planet>
+      <name>Kepler-113 c</name>
+      <name>KOI-153.01</name>
+      <name>KOI-153 c</name>
+      <name>KIC 12252424 c</name>
+      <period>8.92507000</period>
+      <radius errorminus="0.005468" errorplus="0.005468">0.198664</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-113 b</name>
+      <name>KOI-153.02</name>
+      <name>KOI-153 b</name>
+      <name>KIC 12252424 b</name>
+      <period>4.75400</period>
+      <radius errorminus="0.004557" errorplus="0.004557">0.165857</radius>
+      <list>Confirmed planets</list>
+      <mass errorminus="0.013212" errorplus="0.013212">0.036805</mass>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>transit</discoverymethod>
+      <istransiting>1</istransiting>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-113. Time Stamp: 19/11/2016 6:02:38 PM
Sources:
[Kepler-113 c](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-113+c)
