### PR TITLE
HD_48265_eu5qv

### DIFF
--- a/systems/HD 48265.xml
+++ b/systems/HD 48265.xml
@@ -1,30 +1,32 @@
 <system>
-	<name>HD 48265</name>
-	<rightascension>06 40 02</rightascension>
-	<declination>-48 32 31</declination>
-	<distance>87.4</distance>
-	<star>
-		<mass>0.93</mass>
-		<magV>8.07</magV>
-		<magB errorminus="0.02" errorplus="0.02">8.78</magB>
-		<magJ errorminus="0.021" errorplus="0.021">6.842</magJ>
-		<magH errorminus="0.061" errorplus="0.061">6.529</magH>
-		<magK errorminus="0.020" errorplus="0.020">6.449</magK>
-		<metallicity>0.17</metallicity>
-		<spectraltype>G5V</spectraltype>
-		<planet>
-			<name>HD 48265 b</name>
-			<list>Confirmed planets</list>
-			<mass>1.16</mass>
-			<period>700</period>
-			<semimajoraxis>1.51</semimajoraxis>
-			<eccentricity>0.18</eccentricity>
-			<discoverymethod>RV</discoverymethod>
-			<lastupdate>09/05/20</lastupdate>
-			<discoveryyear>2008</discoveryyear>
-			<temperature>291.4</temperature>
-		</planet>
-		<name>HD 48265</name>
-		<temperature>5940.0</temperature>
-	</star>
+  <name>HD 48265</name>
+  <rightascension>06 40 02</rightascension>
+  <declination>-48 32 31</declination>
+  <distance>87.4</distance>
+  <star>
+    <name>HD 48265</name>
+    <mass>0.93</mass>
+    <magV>8.07</magV>
+    <magB errorminus="0.02" errorplus="0.02">8.78</magB>
+    <magJ errorminus="0.021" errorplus="0.021">6.842</magJ>
+    <magH errorminus="0.061" errorplus="0.061">6.529</magH>
+    <magK errorminus="0.020" errorplus="0.020">6.449</magK>
+    <metallicity>0.17</metallicity>
+    <spectraltype>G5V</spectraltype>
+    <temperature>5940.0</temperature>
+    <planet>
+      <name>HD 48265 b</name>
+      <list>Confirmed planets</list>
+      <mass></mass>
+      <period>780.30000000</period>
+      <semimajoraxis>1.810000</semimajoraxis>
+      <eccentricity errorplus="0.050000" errorminus="-0.050000">0.080000</eccentricity>
+      <discoverymethod>Radial Velocity</discoverymethod>
+      <lastupdate>2016-11-10</lastupdate>
+      <discoveryyear>2009</discoveryyear>
+      <temperature>291.4</temperature>
+      <periastron errorplus="137.5100" errorminus="-137.5100">343.7800</periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated HD 48265. Time Stamp: 19/11/2016 6:02:42 PM
Sources:
[HD 48265 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=HD+48265+b)
