### PR TITLE
HD_97658_kgukg

### DIFF
--- a/systems/HD 97658.xml
+++ b/systems/HD 97658.xml
@@ -1,46 +1,49 @@
 <system>
-	<name>HD 97658</name>
-	<rightascension>11 14 33</rightascension>
-	<declination>+25 42 37</declination>
-	<distance errorminus="0.34" errorplus="0.34">21.11</distance>
-	<star>
-		<name>HD 97658</name>
-		<name>GJ 3651</name>
-		<name>BD +26 2184</name>
-		<name>HIP 54906</name>
-		<temperature errorminus="44" errorplus="44">5119.0</temperature>
-		<mass errorminus="0.05" errorplus="0.05">0.77</mass>
-		<radius errorminus="0.023" errorplus="0.024">0.741</radius>
-		<magV>7.714</magV>
-		<magB>8.569</magB>
-		<magR>7.259</magR>
-		<magI>6.835</magI>
-		<magJ errorminus="0.023" errorplus="0.023">6.203</magJ>
-		<magH errorminus="0.017" errorplus="0.017">5.821</magH>
-		<magK errorminus="0.018" errorplus="0.018">5.734</magK>
-		<metallicity errorminus="0.03" errorplus="0.03">-0.23</metallicity>
-		<age errorminus="0.7" errorplus="0.7">6.1</age>
-		<spectraltype>K1V</spectraltype>
-		<planet>
-			<name>HD 97658 b</name>
-			<name>GJ 3651 b</name>
-			<name>BD +26 2184 b</name>
-			<name>HIP 54906 b</name>
-			<list>Confirmed planets</list>
-			<mass errorminus="0.00248562011" errorplus="0.00261147429">0.023754977</mass>
-			<radius errorminus="0.013670" errorplus="0.016403">0.213245</radius>
-			<period errorminus="0.0015" errorplus="0.0016">9.4903</period>
-			<semimajoraxis errorminus="0.0018" errorplus="0.0017">0.08</semimajoraxis>
-			<eccentricity errorminus="0.044" errorplus="0.061">0.078</eccentricity>
-			<periastron errorminus="61" errorplus="66">351</periastron>
-			<transittime errorminus="0.0053" errorplus="0.0057">2456361.8051</transittime>
-			<inclination errorminus="0.36" errorplus="0.52">89.14</inclination>
-			<discoverymethod>transit</discoverymethod>
-			<description>Models suggest that HD 97658 b has a rocky core that is enveloped in an atmosphere composed of lighter elements. The planet's host star is the second brightest known to host a transiting super-Earth which facilitates folllow-up observations.</description>
-			<lastupdate>14/03/03</lastupdate>
-			<discoveryyear>2010</discoveryyear>
-			<temperature errorminus="13" errorplus="12">757</temperature>
-			<istransiting>1</istransiting>
-		</planet>
-	</star>
+  <name>HD 97658</name>
+  <rightascension>11 14 33</rightascension>
+  <declination>+25 42 37</declination>
+  <distance errorminus="0.34" errorplus="0.34">21.11</distance>
+  <star>
+    <name>HD 97658</name>
+    <name>GJ 3651</name>
+    <name>BD +26 2184</name>
+    <name>HIP 54906</name>
+    <temperature errorminus="44" errorplus="44">5119.0</temperature>
+    <mass errorminus="0.05" errorplus="0.05">0.77</mass>
+    <radius errorminus="0.023" errorplus="0.024">0.741</radius>
+    <magV>7.714</magV>
+    <magB>8.569</magB>
+    <magR>7.259</magR>
+    <magI>6.835</magI>
+    <magJ errorminus="0.023" errorplus="0.023">6.203</magJ>
+    <magH errorminus="0.017" errorplus="0.017">5.821</magH>
+    <magK errorminus="0.018" errorplus="0.018">5.734</magK>
+    <metallicity errorminus="0.03" errorplus="0.03">-0.23</metallicity>
+    <age errorminus="0.7" errorplus="0.7">6.1</age>
+    <spectraltype>K1V</spectraltype>
+    <planet>
+      <name>HD 97658 b</name>
+      <name>GJ 3651 b</name>
+      <name>BD +26 2184 b</name>
+      <name>HIP 54906 b</name>
+      <list>Confirmed planets</list>
+      <mass>0.02473</mass>
+      <radius errorminus="0.013670" errorplus="0.016403">0.213245</radius>
+      <period>9.49090000</period>
+      <semimajoraxis>0.079600</semimajoraxis>
+      <eccentricity errorminus="0.044" errorplus="0.061">0.078</eccentricity>
+      <periastron errorminus="61" errorplus="66">351</periastron>
+      <transittime errorminus="0.0053" errorplus="0.0057">2456361.8051</transittime>
+      <inclination errorminus="0.36" errorplus="0.52">89.14</inclination>
+      <discoverymethod>Radial Velocity</discoverymethod>
+      <description>Models suggest that HD 97658 b has a rocky core that is enveloped in an atmosphere composed of lighter elements. The planet's host star is the second brightest known to host a transiting super-Earth which facilitates folllow-up observations.</description>
+      <lastupdate>2016-10-27</lastupdate>
+      <discoveryyear>2011</discoveryyear>
+      <temperature errorminus="13" errorplus="12">757</temperature>
+      <istransiting>1</istransiting>
+      <eccentricity errorplus="0.059000" errorminus="-0.044000">0.063000</eccentricity>
+      <periastron errorplus="67.0000" errorminus="-63.0000">-9.0000</periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated HD 97658. Time Stamp: 19/11/2016 6:02:45 PM
Sources:
[HD 97658 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=HD+97658+b)
