### PR TITLE
WASP-12_h048y

### DIFF
--- a/systems/WASP-12.xml
+++ b/systems/WASP-12.xml
@@ -1,68 +1,69 @@
 <system>
-	<name>WASP-12</name>
-	<rightascension>06 30 33</rightascension>
-	<declination>+29 40 20</declination>
-	<distance errorminus="30" errorplus="30">250</distance>
-	<binary>
-		<separation errorminus="0.019" errorplus="0.019" unit="arcsec">1.064</separation>
-		<separation errorminus="5" errorplus="5" unit="AU">266</separation>
-		<positionangle>251.3</positionangle>
-		<star>
-			<name>WASP-12</name>
-			<name>WASP-12 A</name>
-			<mass>1.35</mass>
-			<radius>1.599</radius>
-			<magV>11.69</magV>
-			<magR>11.6</magR>
-			<magB errorminus="0.21" errorplus="0.21">12.14</magB>
-			<magJ errorminus="0.021" errorplus="0.021">10.477</magJ>
-			<magH errorminus="0.022" errorplus="0.022">10.228</magH>
-			<magK errorminus="0.020" errorplus="0.020">10.188</magK>
-			<temperature errorminus="64" errorplus="64">6118</temperature>
-			<metallicity>0.3</metallicity>
-			<spectraltype>G0</spectraltype>
-			<planet>
-				<name>WASP-12 b</name>
-				<name>WASP-12 A b</name>
-				<name>2MASS J06303279+2940202 b</name>
-				<list>Confirmed planets</list>
-				<mass>1.404</mass>
-				<radius>1.736</radius>
-				<period>1.0914222</period>
-				<semimajoraxis>0.02293</semimajoraxis>
-				<eccentricity>0.0</eccentricity>
-				<inclination>86</inclination>
-				<spinorbitalignment errorminus="20" errorplus="15">59</spinorbitalignment>
-				<transittime errorminus="0.00028" errorplus="0.00028" unit="BJD">2454508.98074</transittime>
-				<discoverymethod>transit</discoverymethod>
-				<lastupdate>13/07/31</lastupdate>
-				<description>The host star of WASP-12 b is the primary of a hierarchical triple system. The distant binary consists of two M dwarfs.</description>
-				<discoveryyear>2008</discoveryyear>
-				<temperature>2319.7</temperature>
-				<list>Planets in binary systems, S-type</list>
-				<istransiting>1</istransiting>
-			</planet>
-		</star>
-		<binary>
-			<separation errorminus="0.0006" errorplus="0.0006" unit="arcsec">0.0843</separation>
-			<separation errorminus="3" errorplus="3" unit="AU">21</separation>
-			<positionangle>84</positionangle>
-			<star>
-				<name>WASP-12 B</name>
-				<spectraltype>M3V</spectraltype>
-				<magJ errorminus="0.076" errorplus="0.076">14.188</magJ>
-				<magK errorminus="0.11" errorplus="0.11">13.51</magK>
-				<temperature errorminus="53" errorplus="53">3786</temperature>
-				<mass errorminus="0.022" errorplus="0.022">0.561</mass>
-			</star>
-			<star>
-				<name>WASP-12 C</name>
-				<spectraltype>M3V</spectraltype>
-				<magJ errorminus="0.021" errorplus="0.021">14.149</magJ>
-				<magK errorminus="0.036" errorplus="0.036">13.765</magK>
-				<temperature errorminus="90" errorplus="90">3748</temperature>
-				<mass errorminus="0.020" errorplus="0.020">0.540</mass>
-			</star>
-		</binary>
-	</binary>
+  <name>WASP-12</name>
+  <rightascension>06 30 33</rightascension>
+  <declination>+29 40 20</declination>
+  <distance errorminus="30" errorplus="30">250</distance>
+  <binary>
+    <separation errorminus="0.019" errorplus="0.019" unit="arcsec">1.064</separation>
+    <separation errorminus="5" errorplus="5" unit="AU">266</separation>
+    <positionangle>251.3</positionangle>
+    <star>
+      <name>WASP-12</name>
+      <name>WASP-12 A</name>
+      <mass>1.35</mass>
+      <radius>1.599</radius>
+      <magV>11.69</magV>
+      <magR>11.6</magR>
+      <magB errorminus="0.21" errorplus="0.21">12.14</magB>
+      <magJ errorminus="0.021" errorplus="0.021">10.477</magJ>
+      <magH errorminus="0.022" errorplus="0.022">10.228</magH>
+      <magK errorminus="0.020" errorplus="0.020">10.188</magK>
+      <temperature errorminus="64" errorplus="64">6118</temperature>
+      <metallicity>0.3</metallicity>
+      <spectraltype>G0</spectraltype>
+      <planet>
+        <name>WASP-12 b</name>
+        <name>WASP-12 A b</name>
+        <name>2MASS J06303279+2940202 b</name>
+        <list>Planets in binary systems, S-type</list>
+        <mass>1.47000</mass>
+        <radius>1.736</radius>
+        <period>1.09142030</period>
+        <semimajoraxis>0.023400</semimajoraxis>
+        <eccentricity errorplus="" errorminus="">0.000000</eccentricity>
+        <inclination>86</inclination>
+        <spinorbitalignment errorminus="20" errorplus="15">59</spinorbitalignment>
+        <transittime errorminus="0.00028" errorplus="0.00028" unit="BJD">2454508.98074</transittime>
+        <discoverymethod>Transit</discoverymethod>
+        <lastupdate>2016-09-15</lastupdate>
+        <description>The host star of WASP-12 b is the primary of a hierarchical triple system. The distant binary consists of two M dwarfs.</description>
+        <discoveryyear>2009</discoveryyear>
+        <temperature>2319.7</temperature>
+        <istransiting>1</istransiting>
+        <periastron errorplus="" errorminus=""></periastron>
+        <periastrontime errorplus="" errorminus=""></periastrontime>
+      </planet>
+    </star>
+    <binary>
+      <separation errorminus="0.0006" errorplus="0.0006" unit="arcsec">0.0843</separation>
+      <separation errorminus="3" errorplus="3" unit="AU">21</separation>
+      <positionangle>84</positionangle>
+      <star>
+        <name>WASP-12 B</name>
+        <spectraltype>M3V</spectraltype>
+        <magJ errorminus="0.076" errorplus="0.076">14.188</magJ>
+        <magK errorminus="0.11" errorplus="0.11">13.51</magK>
+        <temperature errorminus="53" errorplus="53">3786</temperature>
+        <mass errorminus="0.022" errorplus="0.022">0.561</mass>
+      </star>
+      <star>
+        <name>WASP-12 C</name>
+        <spectraltype>M3V</spectraltype>
+        <magJ errorminus="0.021" errorplus="0.021">14.149</magJ>
+        <magK errorminus="0.036" errorplus="0.036">13.765</magK>
+        <temperature errorminus="90" errorplus="90">3748</temperature>
+        <mass errorminus="0.020" errorplus="0.020">0.540</mass>
+      </star>
+    </binary>
+  </binary>
 </system>


### PR DESCRIPTION
Updated WASP-12. Time Stamp: 19/11/2016 6:02:46 PM
Sources:
[WASP-12 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=WASP-12+b)
