### PR TITLE
Kepler-407_e1725

### DIFF
--- a/systems/Kepler-407.xml
+++ b/systems/Kepler-407.xml
@@ -1,49 +1,53 @@
 <system>
-	<name>Kepler-407</name>
-	<name>KOI-1442</name>
-	<name>KIC 11600889</name>
-	<rightascension>19 04 09</rightascension>
-	<declination>+49 36 52</declination>
-	<distance>326.4</distance>
-	<star>
-		<magJ errorminus="0.024" errorplus="0.024">11.332</magJ>
-		<magH errorminus="0.028" errorplus="0.028">10.983</magH>
-		<magK errorminus="0.023" errorplus="0.023">10.911</magK>
-		<name>Kepler-407</name>
-		<name>KOI-1442</name>
-		<name>KIC 11600889</name>
-		<temperature errorminus="75" errorplus="75">5476</temperature>
-		<metallicity errorminus="0.07" errorplus="0.07">0.33</metallicity>
-		<mass errorminus="0.06" errorplus="0.06">1.00</mass>
-		<radius errorminus="0.07" errorplus="0.07">1.01</radius>
-		<age>7.47</age>
-		<planet>
-			<name>Kepler-407 b</name>
-			<name>KOI-1442.01</name>
-			<name>KOI-1442 b</name>
-			<name>KIC 11600889 b</name>
-			<period>0.669310</period>
-			<radius errorminus="0.001823" errorplus="0.001823">0.097509</radius>
-			<mass upperlimit="0.010066" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-407 c</name>
-			<name>KOI-1442.10</name>
-			<name>KOI-1442 c</name>
-			<name>KIC 11600889 c</name>
-			<period errorminus="500" errorplus="500">3000</period>
-			<mass errorminus="6.291401" errorplus="6.291401">12.582803</mass>
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered during a radial velocity follow up of stars observed by Kepler which host planet candidates. Although other planets in this system are transiting, this one is not.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>RV</discoverymethod>
-		</planet>
-	</star>
+  <name>Kepler-407</name>
+  <name>KOI-1442</name>
+  <name>KIC 11600889</name>
+  <rightascension>19 04 09</rightascension>
+  <declination>+49 36 52</declination>
+  <distance>326.4</distance>
+  <star>
+    <name>Kepler-407</name>
+    <name>KOI-1442</name>
+    <name>KIC 11600889</name>
+    <magJ errorminus="0.024" errorplus="0.024">11.332</magJ>
+    <magH errorminus="0.028" errorplus="0.028">10.983</magH>
+    <magK errorminus="0.023" errorplus="0.023">10.911</magK>
+    <temperature errorminus="75" errorplus="75">5476</temperature>
+    <metallicity errorminus="0.07" errorplus="0.07">0.33</metallicity>
+    <mass errorminus="0.06" errorplus="0.06">1.00</mass>
+    <radius errorminus="0.07" errorplus="0.07">1.01</radius>
+    <age>7.47</age>
+    <planet>
+      <name>Kepler-407 b</name>
+      <name>KOI-1442.01</name>
+      <name>KOI-1442 b</name>
+      <name>KIC 11600889 b</name>
+      <period>0.66931000</period>
+      <radius errorminus="0.001823" errorplus="0.001823">0.097509</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+    <planet>
+      <name>Kepler-407 c</name>
+      <name>KOI-1442.10</name>
+      <name>KOI-1442 c</name>
+      <name>KIC 11600889 c</name>
+      <period errorminus="500" errorplus="500">3000</period>
+      <mass errorminus="6.291401" errorplus="6.291401">12.582803</mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered during a radial velocity follow up of stars observed by Kepler which host planet candidates. Although other planets in this system are transiting, this one is not.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>14/02/24</lastupdate>
+      <discoverymethod>RV</discoverymethod>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-407. Time Stamp: 19/11/2016 6:02:52 PM
Sources:
[Kepler-407 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-407+b)
