### PR TITLE
Kepler-409_91o01

### DIFF
--- a/systems/Kepler-409.xml
+++ b/systems/Kepler-409.xml
@@ -1,38 +1,42 @@
 <system>
-	<name>Kepler-409</name>
-	<name>KOI-1925</name>
-	<name>KIC 9955598</name>
-	<rightascension>19 34 43</rightascension>
-	<declination>+46 51 09</declination>
-	<distance>69.2</distance>
-	<star>
-		<magB errorminus="0.04" errorplus="0.04">10.36</magB>
-		<magV errorminus="0.03" errorplus="0.03">9.64</magV>
-		<magJ errorminus="0.018" errorplus="0.018">8.200</magJ>
-		<magH errorminus="0.020" errorplus="0.020">7.838</magH>
-		<magK errorminus="0.023" errorplus="0.023">7.768</magK>
-		<name>Kepler-409</name>
-		<name>KOI-1925</name>
-		<name>KIC 9955598</name>
-		<temperature errorminus="75" errorplus="75">5460</temperature>
-		<metallicity errorminus="0.10" errorplus="0.10">0.08</metallicity>
-		<mass errorminus="0.06" errorplus="0.06">0.92</mass>
-		<radius errorminus="0.02" errorplus="0.02">0.89</radius>
-		<age>6.80</age>
-		<planet>
-			<name>Kepler-409 b</name>
-			<name>KOI-1925.01</name>
-			<name>KOI-1925 b</name>
-			<name>KIC 9955598 b</name>
-			<period>68.9584</period>
-			<radius errorminus="0.002734" errorplus="0.002734">0.108445</radius>
-			<mass upperlimit="0.069205" />
-			<list>Confirmed planets</list>
-			<description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
-			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/24</lastupdate>
-			<discoverymethod>transit</discoverymethod>
-			<istransiting>1</istransiting>
-		</planet>
-	</star>
+  <name>Kepler-409</name>
+  <name>KOI-1925</name>
+  <name>KIC 9955598</name>
+  <rightascension>19 34 43</rightascension>
+  <declination>+46 51 09</declination>
+  <distance>69.2</distance>
+  <star>
+    <name>Kepler-409</name>
+    <name>KOI-1925</name>
+    <name>KIC 9955598</name>
+    <magB errorminus="0.04" errorplus="0.04">10.36</magB>
+    <magV errorminus="0.03" errorplus="0.03">9.64</magV>
+    <magJ errorminus="0.018" errorplus="0.018">8.200</magJ>
+    <magH errorminus="0.020" errorplus="0.020">7.838</magH>
+    <magK errorminus="0.023" errorplus="0.023">7.768</magK>
+    <temperature errorminus="75" errorplus="75">5460</temperature>
+    <metallicity errorminus="0.10" errorplus="0.10">0.08</metallicity>
+    <mass errorminus="0.06" errorplus="0.06">0.92</mass>
+    <radius errorminus="0.02" errorplus="0.02">0.89</radius>
+    <age>6.80</age>
+    <planet>
+      <name>Kepler-409 b</name>
+      <name>KOI-1925.01</name>
+      <name>KOI-1925 b</name>
+      <name>KIC 9955598 b</name>
+      <period>68.95840000</period>
+      <radius errorminus="0.002734" errorplus="0.002734">0.108445</radius>
+      <mass></mass>
+      <list>Confirmed planets</list>
+      <description>This planet has been discovered by the Kepler spacecraft. It was confirmed using a combination of high resolution imaging and spectroscopy and Doppler spectroscopy. This analysis pushes the false probability below 1 percent and puts contraints on the planet's size and mass.</description>
+      <discoveryyear>2014</discoveryyear>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoverymethod>Transit</discoverymethod>
+      <istransiting>1</istransiting>
+      <semimajoraxis></semimajoraxis>
+      <eccentricity errorplus="" errorminus=""></eccentricity>
+      <periastron errorplus="" errorminus=""></periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-409. Time Stamp: 19/11/2016 6:02:54 PM
Sources:
[Kepler-409 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-409+b)
