### PR TITLE
Kepler-56_e3h3o

### DIFF
--- a/systems/Kepler-56.xml
+++ b/systems/Kepler-56.xml
@@ -1,68 +1,71 @@
 <system>
-	<name>Kepler-56</name>
-	<rightascension>19 35 02.01</rightascension>
-	<declination>+41 52 18.7</declination>
-	<star>
-		<name>Kepler-56</name>
-		<name>KOI-1241</name>
-		<name>KIC 6448890</name>
-		<magJ errorminus="0.020" errorplus="0.020">10.813</magJ>
-		<magH errorminus="0.020" errorplus="0.020">10.330</magH>
-		<magK errorminus="0.018" errorplus="0.018">10.227</magK>
-		<mass errorminus="0.13" errorplus="0.13">1.32</mass>
-		<radius errorminus="0.15" errorplus="0.15">4.22</radius>
-		<metallicity errorminus="0.16" errorplus="0.16">0.20</metallicity>
-		<age errorminus="1.3" errorplus="1.3">3.5</age>
-		<temperature errorminus="97" errorplus="97">4840</temperature>
-		<planet>
-			<name>Kepler-56 b</name>
-			<name>KOI-1241.02</name>
-			<name>KOI-1241 b</name>
-			<name>KIC 6448890 b</name>
-			<list>Confirmed planets</list>
-			<mass errorminus="0.0113" errorplus="0.0123">0.0695</mass>
-			<radius errorminus="0.025" errorplus="0.026">0.581</radius>
-			<period errorminus="0.0010" errorplus="0.0011">10.51057</period>
-			<transittime errorminus="0.0057" errorplus="0.0056" unit="BJD">2454978.2556</transittime>
-			<inclination errorminus="0.25" errorplus="0.26">83.92</inclination>
-			<description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 10.50 days for 13.5401 hours. Periodic transit timing variations confirm its planetary nature. The orbit is inclined relative to the stellar equator, which is tilted by 47 ± 6 degrees to the line of sight.</description>
-			<semimajoraxis errorminus="0.0037" errorplus="0.0037">0.1028</semimajoraxis>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>15/04/14</lastupdate>
-			<discoveryyear>2012</discoveryyear>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-56 c</name>
-			<name>KOI-1241.01</name>
-			<name>KOI-1241 c</name>
-			<name>KIC 6448890 c</name>
-			<list>Confirmed planets</list>
-			<mass errorminus="0.060" errorplus="0.066">0.569</mass>
-			<radius errorminus="0.040" errorplus="0.041">0.874</radius>
-			<period errorminus="0.00062" errorplus="0.00059">21.40239</period>
-			<transittime errorminus="0.0055" errorplus="0.0057" unit="BJD">2454978.6560</transittime>
-			<inclination errorminus="0.087" errorplus="0.091">84.08</inclination>
-			<ascendingnode errorminus="3.5" errorplus="3.8">-4.95</ascendingnode>
-			<description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 21.41 days for 11.0797 hours. Periodic transit timing variations confirm its planetary nature. The orbit is inclined relative to the stellar equator, which is tilted by 47 ± 6 degrees to the line of sight.</description>
-			<semimajoraxis errorminus="0.0059" errorplus="0.0059">0.1652</semimajoraxis>
-			<discoverymethod>transit</discoverymethod>
-			<lastupdate>15/04/14</lastupdate>
-			<discoveryyear>2012</discoveryyear>
-			<istransiting>1</istransiting>
-		</planet>
-		<planet>
-			<name>Kepler-56 d</name>
-			<name>KOI-1241 d</name>
-			<name>KIC 6448890 d</name>
-			<list>Controversial</list>
-			<mass>3.3</mass>
-			<eccentricity>0.4</eccentricity>
-			<semimajoraxis>2.0</semimajoraxis>
-			<discoverymethod>RV</discoverymethod>
-			<lastupdate>15/04/14</lastupdate>
-			<discoveryyear>2012</discoveryyear>
-			<description>A linear trend in the radial velocity measurements indicate a third object orbiting Kepler-56, which has tilted the orbits of the inner planets with respect to the stellar equator. So far it has not been possible to confirm the nature of this object from the observations of the system, but it may be a giant planet in a 2 AU orbit.</description>
-		</planet>
-	</star>
+  <name>Kepler-56</name>
+  <rightascension>19 35 02.01</rightascension>
+  <declination>+41 52 18.7</declination>
+  <star>
+    <name>Kepler-56</name>
+    <name>KOI-1241</name>
+    <name>KIC 6448890</name>
+    <magJ errorminus="0.020" errorplus="0.020">10.813</magJ>
+    <magH errorminus="0.020" errorplus="0.020">10.330</magH>
+    <magK errorminus="0.018" errorplus="0.018">10.227</magK>
+    <mass errorminus="0.13" errorplus="0.13">1.32</mass>
+    <radius errorminus="0.15" errorplus="0.15">4.22</radius>
+    <metallicity errorminus="0.16" errorplus="0.16">0.20</metallicity>
+    <age errorminus="1.3" errorplus="1.3">3.5</age>
+    <temperature errorminus="97" errorplus="97">4840</temperature>
+    <planet>
+      <name>Kepler-56 b</name>
+      <name>KOI-1241.02</name>
+      <name>KOI-1241 b</name>
+      <name>KIC 6448890 b</name>
+      <list>Confirmed planets</list>
+      <mass errorminus="0.0113" errorplus="0.0123">0.0695</mass>
+      <radius errorminus="0.025" errorplus="0.026">0.581</radius>
+      <period errorminus="0.0010" errorplus="0.0011">10.51057</period>
+      <transittime errorminus="0.0057" errorplus="0.0056" unit="BJD">2454978.2556</transittime>
+      <inclination errorminus="0.25" errorplus="0.26">83.92</inclination>
+      <description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 10.50 days for 13.5401 hours. Periodic transit timing variations confirm its planetary nature. The orbit is inclined relative to the stellar equator, which is tilted by 47 ± 6 degrees to the line of sight.</description>
+      <semimajoraxis errorminus="0.0037" errorplus="0.0037">0.1028</semimajoraxis>
+      <discoverymethod>transit</discoverymethod>
+      <lastupdate>15/04/14</lastupdate>
+      <discoveryyear>2012</discoveryyear>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-56 c</name>
+      <name>KOI-1241.01</name>
+      <name>KOI-1241 c</name>
+      <name>KIC 6448890 c</name>
+      <list>Confirmed planets</list>
+      <mass errorminus="0.060" errorplus="0.066">0.569</mass>
+      <radius errorminus="0.040" errorplus="0.041">0.874</radius>
+      <period errorminus="0.00062" errorplus="0.00059">21.40239</period>
+      <transittime errorminus="0.0055" errorplus="0.0057" unit="BJD">2454978.6560</transittime>
+      <inclination errorminus="0.087" errorplus="0.091">84.08</inclination>
+      <ascendingnode errorminus="3.5" errorplus="3.8">-4.95</ascendingnode>
+      <description>This planet candidate was discovered by the Kepler spacecraft. It transits its host star every 21.41 days for 11.0797 hours. Periodic transit timing variations confirm its planetary nature. The orbit is inclined relative to the stellar equator, which is tilted by 47 ± 6 degrees to the line of sight.</description>
+      <semimajoraxis errorminus="0.0059" errorplus="0.0059">0.1652</semimajoraxis>
+      <discoverymethod>transit</discoverymethod>
+      <lastupdate>15/04/14</lastupdate>
+      <discoveryyear>2012</discoveryyear>
+      <istransiting>1</istransiting>
+    </planet>
+    <planet>
+      <name>Kepler-56 d</name>
+      <name>KOI-1241 d</name>
+      <name>KIC 6448890 d</name>
+      <list>Controversial</list>
+      <mass></mass>
+      <eccentricity errorplus="0.010000" errorminus="-0.010000">0.200000</eccentricity>
+      <semimajoraxis>2.160000</semimajoraxis>
+      <discoverymethod>Radial Velocity</discoverymethod>
+      <lastupdate>2016-10-13</lastupdate>
+      <discoveryyear>2016</discoveryyear>
+      <description>A linear trend in the radial velocity measurements indicate a third object orbiting Kepler-56, which has tilted the orbits of the inner planets with respect to the stellar equator. So far it has not been possible to confirm the nature of this object from the observations of the system, but it may be a giant planet in a 2 AU orbit.</description>
+      <period>1002.00000000</period>
+      <periastron errorplus="5.7000" errorminus="-5.7000">-15.0000</periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated Kepler-56. Time Stamp: 19/11/2016 6:04:16 PM
Sources:
[Kepler-56 d](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-56+d)
