### PR TITLE
HD_143361_gi8ej

### DIFF
--- a/systems/HD 143361.xml
+++ b/systems/HD 143361.xml
@@ -1,30 +1,32 @@
 <system>
-	<name>HD 143361</name>
-	<rightascension>16 01 50</rightascension>
-	<declination>-44 26 04</declination>
-	<distance>59.35</distance>
-	<star>
-		<mass>0.95</mass>
-		<magV>9.2</magV>
-		<magB>9.93</magB>
-		<magJ errorminus="0.026" errorplus="0.026">7.905</magJ>
-		<magH errorminus="0.038" errorplus="0.038">7.572</magH>
-		<magK errorminus="0.018" errorplus="0.018">7.488</magK>
-		<metallicity>0.29</metallicity>
-		<spectraltype>G0V</spectraltype>
-		<planet>
-			<name>HD 143361 b</name>
-			<list>Confirmed planets</list>
-			<mass>3.12</mass>
-			<period>1057</period>
-			<semimajoraxis>2</semimajoraxis>
-			<eccentricity>0.15</eccentricity>
-			<discoverymethod>RV</discoverymethod>
-			<lastupdate>09/05/20</lastupdate>
-			<discoveryyear>2008</discoveryyear>
-			<temperature>161.0</temperature>
-		</planet>
-		<name>HD 143361</name>
-		<temperature>5940.0</temperature>
-	</star>
+  <name>HD 143361</name>
+  <rightascension>16 01 50</rightascension>
+  <declination>-44 26 04</declination>
+  <distance>59.35</distance>
+  <star>
+    <name>HD 143361</name>
+    <mass>0.95</mass>
+    <magV>9.2</magV>
+    <magB>9.93</magB>
+    <magJ errorminus="0.026" errorplus="0.026">7.905</magJ>
+    <magH errorminus="0.038" errorplus="0.038">7.572</magH>
+    <magK errorminus="0.018" errorplus="0.018">7.488</magK>
+    <metallicity>0.29</metallicity>
+    <spectraltype>G0V</spectraltype>
+    <temperature>5940.0</temperature>
+    <planet>
+      <name>HD 143361 b</name>
+      <list>Confirmed planets</list>
+      <mass></mass>
+      <period>1046.20000000</period>
+      <semimajoraxis>1.980000</semimajoraxis>
+      <eccentricity errorplus="0.015000" errorminus="-0.015000">0.193000</eccentricity>
+      <discoverymethod>Radial Velocity</discoverymethod>
+      <lastupdate>2016-11-10</lastupdate>
+      <discoveryyear>2009</discoveryyear>
+      <temperature>161.0</temperature>
+      <periastron errorplus="3.4400" errorminus="-3.4400">241.2200</periastron>
+      <periastrontime errorplus="" errorminus=""></periastrontime>
+    </planet>
+  </star>
 </system>


### PR DESCRIPTION
Updated HD 143361. Time Stamp: 19/11/2016 6:04:19 PM
Sources:
[HD 143361 b](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=HD+143361+b)
